### PR TITLE
Empty List In NotThe Same As None

### DIFF
--- a/export.py
+++ b/export.py
@@ -638,32 +638,32 @@ def get_primvars(ob, geo, interpolation=""):
     if rm.export_smooth_normals and ob.renderman.primitive in \
             ('AUTO', 'POLYGON_MESH', 'SUBDIVISION_MESH'):
         N = get_mesh_vertex_N(geo)
-        if N is not None:
+        if len(N) > 0:
             primvars["varying normal N"] = N
     if rm.export_default_uv:
         uvs = get_mesh_uv(geo)
-        if uvs is not None:
+        if len(uvs) > 0:
             primvars["%s float[2] st" % interpolation] = uvs
     if rm.export_default_vcol:
         vcols = get_mesh_vcol(geo)
-        if vcols is not None:
+        if len(vcols) > 0:
             primvars["%s color Cs" % interpolation] = rib(vcols)
     
     # custom prim vars
     for p in rm.prim_vars:
         if p.data_source == 'VERTEX_COLOR':
             vcols = get_mesh_vcol(geo, p.data_name)
-            if vcols is not None:
+            if len(vcols) > 0:
                 primvars["%s color %s" % (interpolation, p.name)] = rib(vcols)
 
         elif p.data_source == 'UV_TEXTURE':
             uvs = get_mesh_uv(geo, p.data_name)
-            if uvs is not None:
+            if len(uvs) > 0:
                 primvars["%s float[2] %s" % (interpolation, p.name)] = uvs
 
         elif p.data_source == 'VERTEX_GROUP':
             weights = get_mesh_vgroup(ob, geo, p.data_name)
-            if weights is not None:
+            if len(weights) > 0:
                 primvars["vertex float %s" % p.name] = weights
 
     return primvars


### PR DESCRIPTION
We have to be careful when we check for return values. An empty list is not the same as None. I just discovered this in get_primvars. There may be other cases within the code I have not detected. Be careful using the is not None technique. It only works if your calling def actually returns None.