### PR TITLE
Fix the path to osl shaders.

### DIFF
--- a/properties.py
+++ b/properties.py
@@ -502,7 +502,7 @@ class RendermanSceneSettings(bpy.types.PropertyGroup):
                 name="Shader Output Path", 
                 description="Path to compiled .oso files",
                 subtype='FILE_PATH' ,
-                default="$OUT/shaders")
+                default="./shaders")
     
     output_action = EnumProperty(
                 name="Action",


### PR DESCRIPTION
I tried using the previous fix but it does not work PRMan keeps giving errors. I think a relative path would be also be better and its what all the osl example files use. Also the interactive rendering mode does not use OSL no matter what path its given. See #76 for more information.