### PR TITLE
First batch of fixes and additions for 1.0

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -26,7 +26,7 @@ import bpy
 import sys
 
 bl_info = {
-    "name": "PRMan For Blender",
+    "name": "RenderMan For Blender",
     "author": "Brian Savery",
     "version": (0, 7, 0),
     "blender": (2, 74, 0),
@@ -40,7 +40,7 @@ from . import engine
 
 class PRManRender(bpy.types.RenderEngine):
     bl_idname = 'PRMAN_RENDER'
-    bl_label = "PRMan Render"
+    bl_label = "RenderMan Render"
     bl_use_preview = True
     bl_use_save_buffers = True
 

--- a/engine.py
+++ b/engine.py
@@ -191,6 +191,7 @@ class RPass:
 
         self.paths['render_output'] = user_path(rm.path_display_driver_image,
                                                 scene=scene)
+        debug("info",self.paths)
         self.paths['shader'] = [user_path(rm.out_dir, scene=scene)] +\
             get_path_list_converted(rm, 'shader')
         self.paths['rixplugin'] = get_path_list_converted(rm, 'rixplugin')

--- a/export.py
+++ b/export.py
@@ -2358,6 +2358,11 @@ def export_display(ri, rpass, scene):
         source = aov.channel_type
         if aov.channel_type == 'custom':
             source = aov.custom_lpe
+            exposure_gain = aov.exposure_gain
+            exposure_gamma = aov.exposure_gamma
+            remap_a = aov.remap_a
+            remap_b = aov.remap_b
+            remap_c = aov.remap_c
             # looks like someone didn't set an lpe string
             if source == '':
                 continue
@@ -2382,6 +2387,7 @@ def export_display(ri, rpass, scene):
 
     main_display = user_path(rm.path_display_driver_image,
                              scene=scene)
+    debug("info", "Main_display: " + main_display)
     main_display = os.path.relpath(main_display, rpass.paths['export_dir'])
     image_base, ext = main_display.rsplit('.', 1)
     ri.Display(main_display, dspy_driver, "rgba",

--- a/export.py
+++ b/export.py
@@ -2356,13 +2356,13 @@ def export_display(ri, rpass, scene):
 
     for aov in custom_aovs:
         source = aov.channel_type
+        exposure_gain = aov.exposure_gain
+        exposure_gamma = aov.exposure_gamma
+        remap_a = aov.remap_a
+        remap_b = aov.remap_b
+        remap_c = aov.remap_c
         if aov.channel_type == 'custom':
             source = aov.custom_lpe
-            exposure_gain = aov.exposure_gain
-            exposure_gamma = aov.exposure_gamma
-            remap_a = aov.remap_a
-            remap_b = aov.remap_b
-            remap_c = aov.remap_c
             # looks like someone didn't set an lpe string
             if source == '':
                 continue
@@ -2373,7 +2373,10 @@ def export_display(ri, rpass, scene):
             source = source.replace("%G", G_string)
             source = source.replace("%LG", LG_string)
 
-        params = {"string source": "color " + source}
+        params = {"string source": "color " + source, 
+                  "float[2] exposure": [exposure_gain,exposure_gamma],
+                  "float[3] remap": [remap_a,remap_b,remap_c]}
+        debug("info", params)
         ri.DisplayChannel('varying color %s' % (aov.name), params)
 
     if(rm.display_driver == 'it'):

--- a/export.py
+++ b/export.py
@@ -2376,7 +2376,6 @@ def export_display(ri, rpass, scene):
         params = {"string source": "color " + source, 
                   "float[2] exposure": [exposure_gain,exposure_gamma],
                   "float[3] remap": [remap_a,remap_b,remap_c]}
-        debug("info", params)
         ri.DisplayChannel('varying color %s' % (aov.name), params)
 
     if(rm.display_driver == 'it'):

--- a/properties.py
+++ b/properties.py
@@ -538,8 +538,6 @@ class RendermanSceneSettings(bpy.types.PropertyGroup):
         items = [('openexr', 'OpenEXR', 'Render to a OpenEXR file, to be read back into Blender\'s Render Result'),
                  ('tiff', 'Tiff',
                   'Render to a TIFF file, to be read back into Blender\'s Render Result'),
-                 ('png', 'PNG',
-                  'Render to a PNG file, to be read back into Blender\'s Render Result'),
                  ('it', 'it', 'External framebuffer display (must have RMS installed)')]
         return items
 

--- a/properties.py
+++ b/properties.py
@@ -25,6 +25,7 @@
 
 import bpy
 import os
+import sys
 import xml.etree.ElementTree as ET
 import time
 
@@ -263,7 +264,31 @@ class RendermanAOV(bpy.types.PropertyGroup):
         default=""
     )
 
+    exposure_gain = FloatProperty(
+        name="Gain",
+        description="The gain of the exposure.",
+        default=1.0)
 
+    exposure_gamma = FloatProperty(
+        name="Gamma",
+        description="The gamma of the exposure.",
+        default=1.0)
+
+    remap_a = FloatProperty(
+        name="a",
+        description="A value for remap.",
+        default=0.0)
+
+    remap_b = FloatProperty(
+        name="b",
+        description="B value for remap.",
+        default=0.0)
+
+    remap_c = FloatProperty(
+        name="c",
+        description="C value for remap.",
+        default=0.0)
+        
 class RendermanAOVList(bpy.types.PropertyGroup):
     render_layer = StringProperty()
     custom_aovs = CollectionProperty(type=RendermanAOV,
@@ -528,11 +553,18 @@ class RendermanSceneSettings(bpy.types.PropertyGroup):
         description="Denoise the image.  This will let set your sampling values low and get faster render times and runs denoise to remove the noise as a post process.",
         default=False)
 
-    path_display_driver_image = StringProperty(
-        name="Display Image",
-        description="Render output path to export as the Display in the RIB file. When later rendering the RIB file manually, this will be the raw render result directly from the renderer, and won't pass through blender's render pipeline",
-        subtype='FILE_PATH',
-        default="$OUT/images/{scene}_####.{file_type}")
+    if sys.platform == ("win32"):
+        path_display_driver_image = StringProperty(
+            name="Display Image",
+            description="Render output path to export as the Display in the RIB file. When later rendering the RIB file manually, this will be the raw render result directly from the renderer, and won't pass through blender's render pipeline",
+            subtype='FILE_PATH',
+            default="$OUT\images\{scene}_####.{file_type}")
+    else:
+        path_display_driver_image = StringProperty(
+            name="Display Image",
+            description="Render output path to export as the Display in the RIB file. When later rendering the RIB file manually, this will be the raw render result directly from the renderer, and won't pass through blender's render pipeline",
+            subtype='FILE_PATH',
+            default="$OUT/images/{scene}_####.{file_type}")
 
     update_frequency = FloatProperty(
         name="Update frequency",

--- a/ui.py
+++ b/ui.py
@@ -979,6 +979,13 @@ class RENDER_PT_layer_custom_aovs(CollectionPanel, Panel):
         col.prop(item, "exposure_gain")
         col.prop(item, "exposure_gamma")
         
+        col = layout.column()
+        col.label("Remap Settings")
+        row = col.row(align=True)
+        row.prop(item, "remap_a", text="A")
+        row.prop(item, "remap_b", text="B")
+        row.prop(item, "remap_c", text="C")
+
         col.prop(item, "show_advanced")
         col = col.column()
         col.enabled = item.show_advanced

--- a/ui.py
+++ b/ui.py
@@ -313,7 +313,7 @@ class RENDER_PT_renderman_advanced_settings(PRManButtonsPanel, Panel):
         row.prop(rm, "shadingrate")
 
         layout.separator()
-
+        
         row = layout.row()
         row.label("Pixel Filter:")
         row.prop(rm, "pixelfilter", text="")
@@ -973,6 +973,12 @@ class RENDER_PT_layer_custom_aovs(CollectionPanel, Panel):
         col.prop(item, "channel_type")
         if item.channel_type == "custom":
             col.prop(item, 'custom_lpe')
+        
+        col = layout.column()
+        col.label("Exposure Settings")
+        col.prop(item, "exposure_gain")
+        col.prop(item, "exposure_gamma")
+        
         col.prop(item, "show_advanced")
         col = col.column()
         col.enabled = item.show_advanced


### PR DESCRIPTION
List of fixes and additions include.
Path issue- Not sure if this fixes every problem but it at least it deals with the backslashes.
Exposed exposure and remap options to custom AOV's.
Disable PNG display driver for the time being.
Renamed the Plug-in on the user interface according to planning for 1.0 release.
Added a debug for path information in case it needs to be collected.