### PR TITLE
RIB archiving First pass.

### DIFF
--- a/export.py
+++ b/export.py
@@ -1888,10 +1888,12 @@ def export_data_archives(ri, scene, rpass, data_blocks):
             export_dupli_archive(ri, scene, rpass, db, data_blocks)
         ri.End()
 
-def export_RIBArchive_data_archive(ri, scene, rpass, data_blocks):
+def export_RIBArchive_data_archive(ri, scene, rpass, data_blocks, exportMaterials):
     for name, db in data_blocks.items():
         if not db.do_export:
             continue
+        if(db.material and exportMaterials):
+            export_material_archive(ri, db.material)
         if db.type == "MESH":
             export_mesh_archive(ri, scene, db)
         elif db.type == "PSYS":
@@ -1956,36 +1958,18 @@ def export_data_rib_archive(ri, data_block, instance , rpass):
     relPath = get_real_path(arvhiveInfo.path_archive)
 
     
-    dataFromArchive = import_archive_manifest(arvhiveInfo.path_archive)
+    #dataFromArchive = import_archive_manifest(arvhiveInfo.path_archive)
     
     objectName = dataFromArchive['objectName']
     objectMaterial = dataFromArchive['objectMaterial']
     
-    if(objectMaterial == None):
-        materialInArchive = False
-    else:
-        materialInArchive = True
 
-    archiveAnimated = dataFromArchive['animated']
+    #archiveAnimated = 
 
-    if materialInArchive:
-        if arvhiveInfo.archive_anim_settings.animated_sequence and archiveAnimated:
-            relPath += "This is a test really need some frames here."
-            ri.ReadArchive(relPath)
-        else:
-            relPath += "!materials.rib"
-            ri.ReadArchive(relPath)
-    
     ri.AttributeBegin()
     
 
-
-
-    if(materialInArchive):
-        ri.ReadArchive( 'material.' + objectMaterial)
-
         
-    #Replace with dataFromArchive before deployment.
     archive_filename = get_real_path(arvhiveInfo.path_archive) + "!" + objectName +".rib"
     bounds = get_bounding_box(data_block.data)
     params = {"string filename": archive_filename,
@@ -1995,7 +1979,7 @@ def export_data_rib_archive(ri, data_block, instance , rpass):
     
     
     ri.AttributeEnd()
-    
+    '''
     #This is the point we deal with partical systems
     psysList = dataFromArchive['physics']
     if(psysList):
@@ -2015,7 +1999,7 @@ def export_data_rib_archive(ri, data_block, instance , rpass):
             ri.ReadArchive(psysFilePath)
             
             ri.AttributeEnd()
-
+'''
 def export_archive(*args):
     pass
 
@@ -2696,7 +2680,7 @@ def export_hider(ri, rpass, scene, preview=False):
         ri.Hider(rm.hider, hider_params)
 
 
-# I hate to make rpass global but it makes so much easier
+# I hate to make rpass global but it makes things so much easier
 def write_rib(rpass, scene, ri):
 
     # precalculate motion blur data
@@ -2833,23 +2817,20 @@ def write_archive_RIB(rpass, scene, ri, object, overridePath, exportMats, export
                         export_material(ri, materialSlot.material)
                         ri.ArchiveEnd()
                 else:
-                    useMaterials = False
                     ri.End()
         else:
             archivePath = object.name + ".rib"
             ri.Begin(archivePath)
             debug('info', "Second path: ", archivePath)
-            export_RIBArchive_data_archive(ri, scene, rpass, data_blocks)
             #If we need to export material bake it in
             if(exportMats):
-                useMaterials = True
                 materialsList = object.material_slots
                 for materialSlot in materialsList:
                     ri.ArchiveBegin('material.' + materialSlot.name)
                     export_material(ri, materialSlot.material)
                     ri.ArchiveEnd()
-            else:
-                useMaterials = False
+            export_RIBArchive_data_archive(ri, scene, rpass, data_blocks, exportMats)
+
             ri.End()
         ri.End()
     

--- a/export.py
+++ b/export.py
@@ -1879,6 +1879,7 @@ def export_data_archives(ri, scene, rpass, data_blocks):
         if not db.do_export:
             continue
         ri.Begin(db.archive_filename)
+        debug('info', db.archive_filename)
         if db.type == "MESH":
             export_mesh_archive(ri, scene, db)
         elif db.type == "PSYS":
@@ -1887,6 +1888,17 @@ def export_data_archives(ri, scene, rpass, data_blocks):
             export_dupli_archive(ri, scene, rpass, db, data_blocks)
         ri.End()
 
+def export_RIBArchive_data_archive(ri, scene, rpass, data_blocks):
+    for name, db in data_blocks.items():
+        if not db.do_export:
+            continue
+        if db.type == "MESH":
+            export_mesh_archive(ri, scene, db)
+        elif db.type == "PSYS":
+            export_particle_archive(ri, scene, rpass, db)
+        elif db.type == "DUPLI":
+            export_dupli_archive(ri, scene, rpass, db, data_blocks)
+        
 
 # export each data read archive
 def export_instance_read_archive(ri, instance, instances, data_blocks, rpass, is_child=False):
@@ -2791,10 +2803,11 @@ def write_archive_RIB(rpass, scene, ri, object, overridePath, exportMats, export
     if(overridePath != ""):
         archivePath = os.path.join(os.path.split(overridePath)[0], object.name + fileExt)
         ri.Begin(archivePath)
-        ri.End()
+        debug('info', archivePath)
+        #ri.End()
     else:
         success = False
-        '''
+        
     if(success == True):
         # export rib archives of objects
         if(exportRange):
@@ -2823,25 +2836,26 @@ def write_archive_RIB(rpass, scene, ri, object, overridePath, exportMats, export
                     useMaterials = False
                     ri.End()
         else:
-            export_data_archives(ri, scene, rpass, data_blocks)
-            #If we need to export material do it
+            archivePath = object.name + ".rib"
+            ri.Begin(archivePath)
+            debug('info', "Second path: ", archivePath)
+            export_RIBArchive_data_archive(ri, scene, rpass, data_blocks)
+            #If we need to export material bake it in
             if(exportMats):
                 useMaterials = True
                 materialsList = object.material_slots
-                ri.Begin("materials.rib")
                 for materialSlot in materialsList:
                     ri.ArchiveBegin('material.' + materialSlot.name)
                     export_material(ri, materialSlot.material)
                     ri.ArchiveEnd()
-                ri.End()
             else:
                 useMaterials = False
+            ri.End()
         ri.End()
     
-    
     #Export manifest file
-    success = export_archive_manifest(archivePath, data_blocks, exportRange, scene, useMaterials)
-    '''
+    #success = export_archive_manifest(archivePath, data_blocks, exportRange, scene, useMaterials)
+    
         
     returnList = [success, archivePath]
     return returnList

--- a/export.py
+++ b/export.py
@@ -1913,13 +1913,18 @@ def export_data_archives(ri, scene, rpass, data_blocks):
             export_dupli_archive(ri, scene, rpass, db, data_blocks)
         ri.End()
 
-def export_RIBArchive_data_archive(ri, scene, rpass, data_blocks, exportMaterials, correctionMatrix=None):
+def export_RIBArchive_data_archive(ri, scene, rpass, data_blocks, exportMaterials, objectMatrix=None ,correctionMatrix=None):
     for name, db in data_blocks.items():
         if not db.do_export:
             continue
         if(db.material and exportMaterials):
             export_material_archive(ri, db.material)
         if db.type == "MESH":
+            if(objectMatrix is not None):
+                loc, rot, sca = objectMatrix.decompose()
+                #ri.Translate(loc.x, loc.y, loc.z)
+                ri.Rotate(math.degrees(rot.w), math.degrees(rot.x), math.degrees(rot.y), math.degrees(rot.z))
+                ri.Scale(sca.x, sca.y, sca.z)
             export_mesh_archive(ri, scene, db)
         elif db.type == "PSYS":
             export_particle_archive(ri, scene, rpass, db, correctionMatrix)
@@ -1994,9 +1999,9 @@ def export_data_rib_archive(ri, data_block, instance , rpass):
 
         
     archive_filename = relPath + archiveFileExtention + "!" + objectName +".rib"
-    bounds = get_bounding_box(data_block.data)
+    #bounds = get_bounding_box(data_block.data)
     params = {"string filename": archive_filename,
-            "float[6] bound": bounds}
+            "float[6] bound": [-10000, 10000, -10000, 10000, -10000, 10000]}
     ri.Procedural2(ri.Proc2DelayedReadArchive, ri.SimpleBound, params)
     
     
@@ -2044,7 +2049,7 @@ def export_empties_archives(ri, ob):
     archive_filename = relPath + archiveFileExtention + "!" + objectName +".rib"
     #bounds = get_bounding_box(object)
     params = {"string filename": archive_filename,
-            "float[6] bound": [-1, 1, -1, 1, -1, 1]}
+            "float[6] bound": [-10000, 10000, -10000, 10000, -10000, 10000]}
     ri.Procedural2(ri.Proc2DelayedReadArchive, ri.SimpleBound, params)
     ri.AttributeEnd()
     ri.AttributeEnd()
@@ -2876,7 +2881,7 @@ def write_archive_RIB(rpass, scene, ri, object, overridePath, exportMats, export
                     fileName = db.archive_filename
                     db.do_export = True
                     db.archive_filename = os.path.join( zeroFill, os.path.split(fileName)[1])
-                    export_RIBArchive_data_archive(ri, scene, rpass, data_blocks, matrixInverted)
+                    export_RIBArchive_data_archive(ri, scene, rpass, data_blocks, matrixTrasform, matrixInverted)
                 ri.End()
         else:
             archivePathRIB = object.name + ".rib"
@@ -2890,7 +2895,7 @@ def write_archive_RIB(rpass, scene, ri, object, overridePath, exportMats, export
                     ri.ArchiveBegin('material.' + materialSlot.name)
                     export_material(ri, materialSlot.material)
                     ri.ArchiveEnd()
-            export_RIBArchive_data_archive(ri, scene, rpass, data_blocks, exportMats, matrixInverted)
+            export_RIBArchive_data_archive(ri, scene, rpass, data_blocks, exportMats, matrixTrasform, matrixInverted)
             ri.End()
         ri.End()
     

--- a/export.py
+++ b/export.py
@@ -1861,9 +1861,7 @@ def cache_motion(scene, rpass):
 def get_valid_empties(scene, rpass):
     empties = []
     for object in scene.objects:
-        debug('info', "Object type:", object.type)
         if(object.type == 'EMPTY'):
-            debug('info', "Object", object.name)
             if(object.renderman.geometry_source == 'ARCHIVE'):
                 empties.append(object)
     return empties
@@ -1999,10 +1997,7 @@ def export_data_rib_archive(ri, data_block, instance , rpass):
 
         
     archive_filename = relPath + archiveFileExtention + "!" + objectName +".rib"
-    #bounds = get_bounding_box(data_block.data)
-    params = {"string filename": archive_filename,
-            "float[6] bound": [-10000, 10000, -10000, 10000, -10000, 10000]}
-    ri.Procedural2(ri.Proc2DelayedReadArchive, ri.SimpleBound, params)
+    ri.ReadArchive(archive_filename)
     
     
     
@@ -2047,10 +2042,7 @@ def export_empties_archives(ri, ob):
     ri.AttributeBegin()
     
     archive_filename = relPath + archiveFileExtention + "!" + objectName +".rib"
-    #bounds = get_bounding_box(object)
-    params = {"string filename": archive_filename,
-            "float[6] bound": [-10000, 10000, -10000, 10000, -10000, 10000]}
-    ri.Procedural2(ri.Proc2DelayedReadArchive, ri.SimpleBound, params)
+    ri.ReadArchive(archive_filename)
     ri.AttributeEnd()
     ri.AttributeEnd()
     

--- a/operators.py
+++ b/operators.py
@@ -214,14 +214,19 @@ class ExportRIBObject(bpy.types.Operator):
     export_mat = BoolProperty(
         name="Export Material",
         description="Do you want to export the material?",
-        default=False)
+        default=True)
         
     export_all_frames = BoolProperty(
         name="Export All Frames",
         description="Export entire animation time frame",
         default=False)
     
-    filepath = bpy.props.StringProperty(subtype="FILE_PATH")
+    filepath = bpy.props.StringProperty(
+            subtype="FILE_PATH")
+    
+    filename = bpy.props.StringProperty(
+            subtype="FILE_NAME",
+            default="")
     
     @classmethod
     def poll(cls, context):

--- a/operators.py
+++ b/operators.py
@@ -47,7 +47,7 @@ from .export import export_archive
 from .export import get_texture_list
 from .engine import RPass
 from .export import debug
-from .export import write_single_RIB
+from .export import write_archive_RIB
 from .export import EXCLUDED_OBJECT_TYPES
 from . import engine
 
@@ -207,24 +207,70 @@ class StartInteractive(bpy.types.Operator):
         return {'FINISHED'}
 
 class ExportRIBObject(bpy.types.Operator):
-    bl_idname = "object.export_rib_archive"
+    bl_idname = "export.export_rib_archive"
     bl_label = "Export Object as RIB Archive."
     bl_description = "Export single object as a RIB archive for use in other blend files or for other uses."
-    def invoke(self, context, event=None):
-        print("Exporting all the RIB!!" + str(context.active_object))
+
+    export_mat = BoolProperty(
+        name="Export Material",
+        description="Do you want to export the material?",
+        default=False)
+        
+    export_all_frames = BoolProperty(
+        name="Export All Frames",
+        description="Export entire animation time frame",
+        default=False)
+    
+    filepath = bpy.props.StringProperty(subtype="FILE_PATH")
+    
+    @classmethod
+    def poll(cls, context):
+        return context.object is not None
+    
+    def execute(self, context):
+        export_path = self.filepath
+        export_range = self.export_all_frames
+        export_mats = self.export_mat
         rpass = RPass(context.scene, interactive=False)
         object = context.active_object
+        
         
         #rpass.convert_textures(get_texture_list(context.scene))
         rpass.ri.Option("rib", {"string asciistyle": "indented,wide"})
         
-        export_filename = write_single_RIB(rpass, context.scene, rpass.ri, object)
+        #export_filename = write_single_RIB(rpass, context.scene, rpass.ri, object)
+        export_sucess = write_archive_RIB(rpass, context.scene, rpass.ri, object,
+                                         export_path, export_mats, export_range)
+
         
-        object.renderman.geometry_source = 'ARCHIVE'
-        object.renderman.path_archive = export_filename
-        object.show_bounds = True
         
+        if(export_sucess[0] == True):
+            self.report({'INFO'}, "Archive Exported Successfully!")
+            object.renderman.geometry_source = 'ARCHIVE'
+            object.renderman.path_archive = export_sucess[1]
+            object.renderman.object_name = object.name
+            if(export_mats):
+                object.renderman.material_in_archive = True
+            else:
+                object.renderman.material_in_archive = False
+            object.show_bounds = True
+            if(export_range == True):
+                object.renderman.archive_anim_settings.animated_sequence = True
+                object.renderman.archive_anim_settings.sequence_in = context.scene.frame_start
+                object.renderman.archive_anim_settings.sequence_out = context.scene.frame_end
+                object.renderman.archive_anim_settings.blender_start = context.scene.frame_current
+            else:
+                object.renderman.archive_anim_settings.animated_sequence = False
+        else:
+            self.report({'ERROR'}, "Archive Not Exported.")
         return {'FINISHED'}
+    
+    def invoke(self, context, event=None):
+        
+        context.window_manager.fileselect_add(self)
+        return{'RUNNING_MODAL'}
+        
+ 
 
 ''' # Item that is not needed because of the switch.
 class ExportRIBArchive(bpy.types.Operator):

--- a/properties.py
+++ b/properties.py
@@ -723,15 +723,15 @@ class RendermanMaterialSettings(bpy.types.PropertyGroup):
 class RendermanAnimSequenceSettings(bpy.types.PropertyGroup):
     animated_sequence = BoolProperty(
         name="Animated Sequence",
-        description="Interpret this texture as an animated sequence (converts #### in file path to frame number)",
+        description="Interpret this archive as an animated sequence (converts #### in file path to frame number)",
         default=False)
     sequence_in = IntProperty(
         name="Sequence In Point",
-        description="The first numbered image file to use",
+        description="The first numbered file to use",
         default=1)
     sequence_out = IntProperty(
         name="Sequence Out Point",
-        description="The last numbered image file to use",
+        description="The last numbered file to use",
         default=24)
     blender_start = IntProperty(
         name="Blender Start Frame",

--- a/ui.py
+++ b/ui.py
@@ -54,6 +54,12 @@ properties_material.MATERIAL_PT_context_material.COMPAT_ENGINES.add(
 properties_material.MATERIAL_PT_custom_props.COMPAT_ENGINES.add('PRMAN_RENDER')
 del properties_material
 
+import bl_ui.properties_scene as properties_scene
+properties_scene.SCENE_PT_scene.COMPAT_ENGINES.add('PRMAN_RENDER')
+properties_scene.SCENE_PT_unit.COMPAT_ENGINES.add('PRMAN_RENDER')
+properties_scene.SCENE_PT_physics.COMPAT_ENGINES.add('PRMAN_RENDER')
+del properties_scene
+
 import bl_ui.properties_data_lamp as properties_data_lamp
 properties_data_lamp.DATA_PT_context_lamp.COMPAT_ENGINES.add('PRMAN_RENDER')
 properties_data_lamp.DATA_PT_spot.COMPAT_ENGINES.add('PRMAN_RENDER')
@@ -921,7 +927,7 @@ class OBJECT_PT_renderman_object_geometry(Panel):
 
             
         col = layout.column()
-        col.operator("object.export_rib_archive", icon="EXPORT", text="Export Object as RIB Archive.")
+        col.operator("export.export_rib_archive", icon="EXPORT", text="Export Object as RIB Archive.")
         
         
         

--- a/ui.py
+++ b/ui.py
@@ -795,6 +795,8 @@ class DATA_PT_renderman_world(ShaderPanel, Panel):
                 (n for n in nt.nodes if n.renderman_node_type == 'output'), None)
             lamp_node = output_node.inputs['Light'].links[0].from_node
             if lamp_node:
+                layout.prop(lamp_node, 'light_primary_visibility')
+                layout.prop(lamp_node, 'light_shading_rate')
                 draw_node_properties_recursive(self.layout, context, nt, lamp_node)
         
 


### PR DESCRIPTION
Allows the use of RIB archives for single frames. Also allows the use of correction matrix for particles in the future (currently works for archives.) In addition to all that empties now are collected by their own functions to determine if they are carrying RIB archive references. So in short you can export and read any renderable object using RIB archives attached again to any type of renderable object (and empties.)