### PR TITLE
Blender version change and OSL improvements 

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -28,10 +28,10 @@ import sys
 bl_info = {
     "name": "RenderMan For Blender",
     "author": "Brian Savery",
-    "version": (0, 7, 0),
-    "blender": (2, 74, 0),
+    "version": (0, 8, 0),
+    "blender": (2, 77, 0),
     "location": "Info Header, render engine menu",
-    "description": "RenderMan 20.0 integration",
+    "description": "RenderMan 21.0 integration",
     "warning": "",
     "category": "Render"}
 

--- a/nodes.py
+++ b/nodes.py
@@ -370,8 +370,7 @@ class RendermanShadingNode(bpy.types.Node):
                     user_path(prefs.env_vars.out), "shaders", FileNameOSO)
         else:
             ok = False
-            debug(
-                "osl", "Shader cannot be compiled. Shader name not specified")
+            debug("osl", "Shader cannot be compiled. Shader name not specified")
         # If Shader compiled successfully then update node.
         if ok:
             debug('osl', "Shader Compiled Successfully!")
@@ -1017,13 +1016,11 @@ def gen_params(ri, node, mat_name=None, recurse=True):
         fileInputType = node.codetypeswitch
         
         for prop_name, meta in node.prop_meta.items():
-            #print (prop_name);
             if prop_name in txmake_options.index or prop_name == "codetypeswitch":
                 pass
             elif prop_name == "internalSearch" and fileInputType == 'INT':
                 if node.internalSearch != "":
                     script = bpy.data.texts[node.internalSearch]
-                    #print("entered INT")
                     params['%s %s' % ("string",
                             "expression")] = \
                                 rib(script.as_string(), type_hint=meta['renderman_type'])
@@ -1031,7 +1028,6 @@ def gen_params(ri, node, mat_name=None, recurse=True):
                 fileInput = user_path(getattr(node, 'shadercode'))
                 if fileInput != "":
                     outputString = ""
-                    #print("Entered EXT")
                     with open(fileInput, encoding='utf-8') as SeExprFile:
                         for line in SeExprFile:
                             outputString += line

--- a/shader_parameters.py
+++ b/shader_parameters.py
@@ -309,7 +309,6 @@ def generate_property(sp):
     if 'coshaderPort' in prop_meta and prop_meta['coshaderPort'] == 'True':
         param_type = 'shader'
 
-    # I guess multiline tooltips never worked
     for s in sp:
         if s.tag == 'help' and s.text:
             param_help = s.text

--- a/util.py
+++ b/util.py
@@ -66,14 +66,15 @@ def readOSO(filePath):
     line_number = 0
     shader_meta = {}
     prop_names = []
+    shader_meta["shader"] = os.path.splitext(os.path.basename(filePath))[0]
+    print("Shader", shader_meta["shader"])
     with open(filePath, encoding='utf-8') as osofile:
         for line in osofile:
-            if line.startswith("surface") or line.startswith("shader"):
-                line_number += 1
-                listLine = line.split()
-                # print("SHADER: ", listLine[1])
-                shader_meta["shader"] = listLine[1]
-            elif line.startswith("param"):
+            #if line.startswith("surface") or line.startswith("shader"):
+            #    line_number += 1
+            #    listLine = line.split()
+            #    shader_meta["shader"] = listLine[1]
+            if line.startswith("param"):
                 line_number += 1
                 listLine = line.split()
                 name = listLine[2]
@@ -95,8 +96,8 @@ def readOSO(filePath):
                         x += 1
                 elif type == "closure":
                     debug('error', "Closure types are not supported")
-                    type = "void"
-                    name = listLine[3]
+                    #type = "void"
+                    #name = listLine[3]
                 else:
                     default = listLine[3]
                 prop_names.append(name)
@@ -128,7 +129,6 @@ def readOSO(filePath):
                 prop_names.append(name)
                 prop_meta = {"type": type, "default":  default, "IO": "out"}
                 shader_meta[name] = prop_meta
-                # print("SHADER: ", shader_meta)
             else:
                 line_number += 1
     return prop_names, shader_meta

--- a/util.py
+++ b/util.py
@@ -67,7 +67,6 @@ def readOSO(filePath):
     shader_meta = {}
     prop_names = []
     shader_meta["shader"] = os.path.splitext(os.path.basename(filePath))[0]
-    print("Shader", shader_meta["shader"])
     with open(filePath, encoding='utf-8') as osofile:
         for line in osofile:
             #if line.startswith("surface") or line.startswith("shader"):


### PR DESCRIPTION
I changed the version of Blender required to be at minimum 2.77 because of the multiline tool tips. Also fixed issue with OSL not outputting to the same file it records in the materials.rib