### PR TITLE
Fixed object group export, added in additional AOV/lpe options

### DIFF
--- a/export.py
+++ b/export.py
@@ -42,6 +42,7 @@ from .util import user_path
 from .util import path_list_convert, get_real_path
 from .util import get_properties, check_if_archive_dirty
 from .util import debug
+
 from .util import find_it_path
 from .nodes import export_shader_nodetree, get_textures
 from .nodes import shader_node_rib, get_bxdf_name
@@ -2061,7 +2062,7 @@ def export_object_attributes(ri, scene, ob, visible_objects):
     obj_groups_str = '*'
     for obj_group in scene.renderman.object_groups:
         if ob.name in obj_group.members.keys():
-            obj_groups_str += ',' + obj_group.name
+            obj_groups_str = obj_group.name
     # add to trace sets
     ri.Attribute("grouping", {"string membership": obj_groups_str})
     # add to lpe groups
@@ -2640,14 +2641,20 @@ def export_display(ri, rpass, scene):
 
     for aov in custom_aovs:
         source = aov.channel_type
+        source_type = "color"
         exposure_gain = aov.exposure_gain
         exposure_gamma = aov.exposure_gamma
         remap_a = aov.remap_a
         remap_b = aov.remap_b
         remap_c = aov.remap_c
-        if aov.channel_type == 'custom':
-            source = aov.custom_lpe
+        if aov.channel_type == 'custom_lpe_string':
+            source = aov.custom_lpe_string
             # looks like someone didn't set an lpe string
+            if source == '':
+                continue
+        if aov.channel_type == 'built_in_aov':
+            source = aov.custom_aov_string
+            source_type = aov.custom_aov_type
             if source == '':
                 continue
         else:
@@ -2657,10 +2664,10 @@ def export_display(ri, rpass, scene):
             source = source.replace("%G", G_string)
             source = source.replace("%LG", LG_string)
 
-        params = {"string source": "color " + source,
+        params = {"string source": source_type + " " + source,
                   "float[2] exposure": [exposure_gain, exposure_gamma],
                   "float[3] remap": [remap_a, remap_b, remap_c]}
-        ri.DisplayChannel('varying color %s' % (aov.name), params)
+        ri.DisplayChannel(source_type + ' %s' % (aov.name), params)
 
     if(rm.display_driver == 'it'):
         if find_it_path() is None:

--- a/export.py
+++ b/export.py
@@ -2059,15 +2059,20 @@ def export_object_attributes(ri, scene, ob, visible_objects):
     #if ob.renderman.do_holdout:
     #    ri.Attribute("identifier", {"string lpegroup": ob.renderman.lpe_group})
     # gather object groups this object belongs to
-    obj_groups_str = '*'
+    obj_groups_str = "*"
     for obj_group in scene.renderman.object_groups:
         if ob.name in obj_group.members.keys():
-            obj_groups_str = obj_group.name
+            obj_groups_str += ',' + obj_group.name
     # add to trace sets
     ri.Attribute("grouping", {"string membership": obj_groups_str})
-    # add to lpe groups
-    ri.Attribute("identifier", {"string lpegroup": obj_groups_str})
 
+    # add to lpe groups
+    #ri.Attribute("identifier", {"string lpegroup": obj_groups_str})
+
+    #Hack for one lpe group per object restriction in Renderman 20.  Can be removed for 21.
+    if obj_groups_str != '*':
+        ri.Attribute("identifier", {"string lpegroup": obj_groups_str.split(',')[1]})
+    
     if ob.renderman.shading_override:
         ri.ShadingRate(ob.renderman.shadingrate)
         approx_params = {}

--- a/properties.py
+++ b/properties.py
@@ -223,7 +223,8 @@ class RendermanPass(bpy.types.PropertyGroup):
 class RendermanAOV(bpy.types.PropertyGroup):
 
     def built_in_channel_types(self, context):
-        items = [('custom', 'Custom', 'Custom Type'),
+        items = [("custom_lpe_string", "Custom lpe", "Custom lpe"),
+                 ("built_in_aov", "Built in AOV", "Built in AOV"),
                  ("lpe:C<.D%G>[S]+<L.%LG>", "Caustics", "Caustics"),
                  ("lpe:shadows;C[<.D%G><.S%G>]<L.%LG>", "Shadows", "Shadows"),
                  ("lpe:C<RS%G>([DS]+<L.%LG>)|([DS]*O)",
@@ -244,7 +245,7 @@ class RendermanAOV(bpy.types.PropertyGroup):
     def update_type(self, context):
         types = self.built_in_channel_types(context)
         for item in types:
-            if self.channel_type == item[0] and self.channel_type != 'custom':
+            if self.channel_type == item[0] and self.channel_type != 'custom_lpe_string' and self.channel_type != 'built_in_aov':
                 self.name = 'Custom_' + item[1]
 
     show_advanced = BoolProperty(name='Advanced', default=False)
@@ -254,10 +255,20 @@ class RendermanAOV(bpy.types.PropertyGroup):
                                 items=built_in_channel_types, update=update_type)
     name = StringProperty(
         name="Channel Name",
-        description="Name for the Channel in the output file")
-    custom_lpe = StringProperty(
+        description="Name for the Channel in the output file.  NOTE: Spaces must be represented by an underscore.  If this is not followed the channel will not output.")
+
+    custom_lpe_string = StringProperty(
         name="lpe String",
-        description="Custom lpe code")
+        description="Custom lpe string")
+
+    custom_aov_string = StringProperty(
+        name="AOV name",
+        description="Name of the built in AOV")
+
+    custom_aov_type = StringProperty(
+        name="AOV type",
+        description="Information type for the AOV (normal, float, vector or color)",
+        default="")
 
     lpe_group = StringProperty(
         name="lpe Group",

--- a/ui.py
+++ b/ui.py
@@ -1088,8 +1088,11 @@ class RENDER_PT_layer_custom_aovs(CollectionPanel, Panel):
         col = layout.column()
         col.prop(item, "name")
         col.prop(item, "channel_type")
-        if item.channel_type == "custom":
-            col.prop(item, 'custom_lpe')
+        if item.channel_type == "custom_lpe_string":
+            col.prop(item, "custom_lpe_string")
+        if item.channel_type == "built_in_aov":
+            col.prop(item, "custom_aov_type")
+            col.prop(item, "custom_aov_string")
         
         col = layout.column()
         col.label("Exposure Settings")
@@ -1103,12 +1106,13 @@ class RENDER_PT_layer_custom_aovs(CollectionPanel, Panel):
         row.prop(item, "remap_b", text="B")
         row.prop(item, "remap_c", text="C")
 
-        col.prop(item, "show_advanced")
-        col = col.column()
-        col.enabled = item.show_advanced
-        col.prop_search(item, 'lpe_group', rm,
+        if item.channel_type != "custom_lpe_string" and item.channel_type != "built_in_aov":
+            col.prop(item, "show_advanced")
+            col = col.column()
+            col.enabled = item.show_advanced
+            col.prop_search(item, 'lpe_group', rm,
                                 "object_groups", text="Object Group")
-        col.prop_search(item, 'lpe_light_group', rm,
+            col.prop_search(item, 'lpe_light_group', rm,
                                 "light_groups", text="Light Group")
         
 


### PR DESCRIPTION
Also made some ui changes in the AOV section that removed the advanced (object group/light group) options unless you're using one of the pre-defined custom lpe's.  Seemed to make sense as you really can't use them with the built in AOV's or the custom lpe string box.