### PR TITLE
Loads all output images into image editor when internal rendering

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -152,6 +152,7 @@ class RPass:
 
     def __init__(self, scene, interactive=False, external_render=False, preview_render=False):
         self.scene = scene
+        self.output_files = []
         #set the display driver 
         if external_render:
             self.display_driver = scene.renderman.display_driver
@@ -493,8 +494,8 @@ class RPass:
                               denoise_data)
                 
         #Load all output images into image editor
-        for image in self.rm.output_files:
-            bpy.ops.image.open(filepath=image.name)
+        for image in self.output_files:
+            bpy.ops.image.open(filepath=image)
 
     def set_scene(self, scene):
         self.scene = scene

--- a/engine.py
+++ b/engine.py
@@ -491,6 +491,10 @@ class RPass:
                 engine.report({"ERROR"},
                               "Cannot denoise file %s. Does not exist" %
                               denoise_data)
+                
+        #Load all output images into image editor
+        for image in self.rm.output_files:
+            bpy.ops.image.open(filepath=image.name)
 
     def set_scene(self, scene):
         self.scene = scene

--- a/export.py
+++ b/export.py
@@ -2740,10 +2740,8 @@ def export_display(ri, rpass, scene):
         ri.DisplayChannel(source_type + ' %s' % (channel_name), params)
 
 
-
-
     display_driver = rpass.display_driver
-    
+    rpass.output_files = []
 
     main_display = user_path(rm.path_display_driver_image, scene=scene, rpass=rpass)
     debug("info", "Main_display: " + main_display)
@@ -2794,15 +2792,15 @@ def export_display(ri, rpass, scene):
             if doit:
                 ri.Display('+' + image_base + '.%s.' % aov + ext,
                         display_driver, aov, {"quantize": [0, 0, 0, 0], "int asrgba": 1})
-                rpass.output_files.append(main_display)
+                rpass.output_files.append(image_base + '.%s.' % aov + ext)
         for aov in custom_aovs:
             if not aov.exclude:
                 if aov.denoise_aov:
                     ri.Display('+' + image_base + '.%s.denoiseable.' % aov.name + ext, display_driver, aov.channel_name, {"quantize": [0, 0, 0, 0]})
-                    rpass.output_files.append(main_display)
+                    rpass.output_files.append(image_base + '.%s.denoiseable.' % aov.name + ext)
                 else:
                     ri.Display('+' + image_base + '.%s.' % aov.name + ext, display_driver, aov.channel_name, {"quantize": [0, 0, 0, 0], "int asrgba": 1})
-                    rpass.output_files.append(main_display)
+                    rpass.output_files.append(image_base + '.%s.' % aov.name + ext)
 
     #exports custom multilayers   
     for multilayer_list in rm.multilayer_lists:

--- a/export.py
+++ b/export.py
@@ -2764,9 +2764,7 @@ def export_display(ri, rpass, scene):
             main_params["string compression"] = rm.exr_compression
             
     ri.Display(main_display, display_driver, "rgba", main_params)
-    rm.output_files_index += 1
-    rm.output_files.add()
-    rm.output_files[rm.output_files_index].name = main_display
+    rpass.output_files.append(main_display)
 
    
         
@@ -2798,21 +2796,17 @@ def export_display(ri, rpass, scene):
     else:
         for aov, doit, declare, source in aovs:
             if doit:
-                rm.output_files_index += 1
                 ri.Display('+' + image_base + '.%s.' % aov + ext,
                         display_driver, aov, {"quantize": [0, 0, 0, 0], "int asrgba": 1})
-                rm.output_files.add()
-                rm.output_files[rm.output_files_index].name = image_base + '.%s.' % aov + ext
+                rpass.output_files.append(main_display)
         for aov in custom_aovs:
             if not aov.exclude:
-                rm.output_files_index += 1
-                rm.output_files.add()
                 if aov.denoise_aov:
                     ri.Display('+' + image_base + '.%s.denoiseable.' % aov.name + ext, display_driver, aov.channel_name, {"quantize": [0, 0, 0, 0]})
-                    rm.output_files[rm.output_files_index].name = image_base + '.%s.denoiseable.' % aov.name + ext
+                    rpass.output_files.append(main_display)
                 else:
                     ri.Display('+' + image_base + '.%s.' % aov.name + ext, display_driver, aov.channel_name, {"quantize": [0, 0, 0, 0], "int asrgba": 1})
-                    rm.output_files[rm.output_files_index].name = image_base + '.%s.' % aov.name + ext
+                    rpass.output_files.append(main_display)
 
     #exports custom multilayers   
     for multilayer_list in rm.multilayer_lists:

--- a/export.py
+++ b/export.py
@@ -2740,10 +2740,6 @@ def export_display(ri, rpass, scene):
         ri.DisplayChannel(source_type + ' %s' % (channel_name), params)
 
 
-    #Flushes any output file names left over from previous render sessions
-    while rm.output_files_index > -1:
-        rm.output_files.remove(rm.output_files_index)
-        rm.output_files_index -= 1
 
 
     display_driver = rpass.display_driver

--- a/properties.py
+++ b/properties.py
@@ -460,6 +460,9 @@ class RendermanMultilayerFileList(bpy.types.PropertyGroup):
     
     multilayer_file_index = IntProperty(min=-1,  default=-1)
 
+class RendermanOutputFiles(bpy.types.PropertyGroup):
+    name = StringProperty()
+
 
 class RendermanSceneSettings(bpy.types.PropertyGroup):
     light_groups = CollectionProperty(type=RendermanGroup,
@@ -492,6 +495,12 @@ class RendermanSceneSettings(bpy.types.PropertyGroup):
         items=[('object', 'Objects', ''),
                ('group', 'Object Groups', '')],
         default='group', update=reset_ll_object_index)
+
+    output_files = CollectionProperty(type=RendermanOutputFiles, 
+                                                name="Output Files")
+    output_files_index = IntProperty(name='', 
+                                                description='', 
+                                                default=-1)
 
 
     aov_lists = CollectionProperty(type=RendermanAOVList,
@@ -1885,6 +1894,7 @@ classes = [RendermanPath,
            RendermanGroup,
            LightLinking,
            TraceSet,
+           RendermanOutputFiles,
            RendermanPass,
            RendermanMultilayerFile, 
            RendermanMultilayerFileList, 

--- a/properties.py
+++ b/properties.py
@@ -460,9 +460,6 @@ class RendermanMultilayerFileList(bpy.types.PropertyGroup):
     
     multilayer_file_index = IntProperty(min=-1,  default=-1)
 
-class RendermanOutputFiles(bpy.types.PropertyGroup):
-    name = StringProperty()
-
 
 class RendermanSceneSettings(bpy.types.PropertyGroup):
     light_groups = CollectionProperty(type=RendermanGroup,
@@ -495,12 +492,6 @@ class RendermanSceneSettings(bpy.types.PropertyGroup):
         items=[('object', 'Objects', ''),
                ('group', 'Object Groups', '')],
         default='group', update=reset_ll_object_index)
-
-    output_files = CollectionProperty(type=RendermanOutputFiles, 
-                                                name="Output Files")
-    output_files_index = IntProperty(name='', 
-                                                description='', 
-                                                default=-1)
 
 
     aov_lists = CollectionProperty(type=RendermanAOVList,
@@ -1894,7 +1885,6 @@ classes = [RendermanPath,
            RendermanGroup,
            LightLinking,
            TraceSet,
-           RendermanOutputFiles,
            RendermanPass,
            RendermanMultilayerFile, 
            RendermanMultilayerFileList, 


### PR DESCRIPTION
Here's a bit more robust solution.  All output files (except custom multilayers, since they don't work right) are added to a list that the engine will comb through after rendering.  All the file names in that list will be loaded into the image editor.  That list is then scrubbed whenever the next render starts, so it won't waste time trying to load images that have already been done or don't exist anymore.