### PR TITLE
Fix for documentation error

### DIFF
--- a/export.py
+++ b/export.py
@@ -2939,7 +2939,7 @@ def export_display(ri, rpass, scene):
             ("albedo", 'color',
              'color lpe:nothruput;noinfinitecheck;noclamp;unoccluded;overwrite;C(U2L)|O',
              None, None),
-            ("albedo_var", 'color', 'color lpe:nothruput;noinfinitecheck;noclamp;unoccluded;overwrite;C<.S\'passthru\'>*((U2L)|O)',
+            ("albedo_var", 'color', 'color lpe:nothruput;noinfinitecheck;noclamp;unoccluded;overwrite;C(U2L)|O',
             "variance", True),
             ("diffuse", 'color', 'color lpe:C(D[DS]*[LO])|O', None, None),
             ("diffuse_mse", 'color', 'color lpe:C(D[DS]*[LO])|O', 'mse', None),


### PR DESCRIPTION
21 docs had different LPE's for albedo and albedo_var.  Renderman didn't like that.