### PR TITLE
Fix for externally spooling animations

### DIFF
--- a/export.py
+++ b/export.py
@@ -2903,7 +2903,7 @@ def export_display(ri, rpass, scene):
                                    aov.channel_name, params)
                         rpass.output_files.append(dspy_name)
 
-    if (rm.do_denoise and not rpass.external_render or rm.external_denoise and rpass.external_render) and not rpass.is_interactive:
+    if (rm.do_denoise and not rpass.external_render or rm.external_denoise and rm.output_action == 'EXPORT') and not rpass.is_interactive:
         # add display channels for denoising
         denoise_aovs = [
             # (name, declare type/name, source, statistics, filter)

--- a/operators.py
+++ b/operators.py
@@ -244,6 +244,7 @@ class ExternalRender(bpy.types.Operator):
         scene = context.scene
         rpass = RPass(scene, external_render=True)
         rm = scene.renderman
+        rm.output_action = "EXPORT"
 
         # rib gen each frame
         rpass.display_driver = scene.renderman.display_driver
@@ -262,7 +263,8 @@ class ExternalRender(bpy.types.Operator):
                 rpass.update_frame_num(frame)
                 self.report(
                     {'INFO'}, 'RenderMan External Rendering generating rib for frame %d' % frame)
-                self.gen_rib_frame(rpass)
+#                self.gen_rib_frame(rpass)
+                bpy.ops.render.render(animation=True)
                 rib_names.append(rpass.paths['rib_output'])
                 frame_tex_cmds[frame] = [cmd for cmd in get_texture_list(rpass.scene) if cmd not in job_tex_cmds]
                 if rm.external_denoise:
@@ -271,7 +273,8 @@ class ExternalRender(bpy.types.Operator):
         else:
             self.report(
                 {'INFO'}, 'RenderMan External Rendering generating rib for frame %d' % scene.frame_current)
-            self.gen_rib_frame(rpass)
+#            self.gen_rib_frame(rpass)
+            bpy.ops.render.render()
             rib_names.append(rpass.paths['rib_output'])
             frame_tex_cmds = {scene.frame_current: get_texture_list(scene)}
             if rm.external_denoise:
@@ -330,6 +333,7 @@ class ExternalRender(bpy.types.Operator):
                 subprocess.Popen([exe, alf_file])
 
         rpass = None
+        rm.output_action = "EXPORT_RENDER"
         return {'FINISHED'}
 
 


### PR DESCRIPTION
Uses the old 'export only' process behind the scenes for external rendering.  Allows deforming object archives to be exported properly during animation.  Still doesn't export animating particles though.