### PR TITLE
Spool filename update

### DIFF
--- a/spool.py
+++ b/spool.py
@@ -1,5 +1,6 @@
 import bpy
 import os
+import time
 from .util import user_path
 
 
@@ -33,7 +34,7 @@ def spool_render(rman_version_short, rib_files, denoise_files, frame_begin, fram
     cdir = user_path(out_dir)
     scene = context.scene
     rm = scene.renderman
-    alf_file = os.path.join(cdir, 'spool.alf')
+    alf_file = os.path.join(cdir, 'spool_%s.alf' % time.strftime("%d%M%S"))
     per_frame_denoise = denoise == 'frame'
     crossframe_denoise = denoise == 'crossframe'
 

--- a/spool.py
+++ b/spool.py
@@ -34,7 +34,7 @@ def spool_render(rman_version_short, rib_files, denoise_files, frame_begin, fram
     cdir = user_path(out_dir)
     scene = context.scene
     rm = scene.renderman
-    alf_file = os.path.join(cdir, 'spool_%s.alf' % time.strftime("%d%M%S"))
+    alf_file = os.path.join(cdir, 'spool_%s.alf' % time.strftime("%m%d%y%H%M%S"))
     per_frame_denoise = denoise == 'frame'
     crossframe_denoise = denoise == 'crossframe'
 


### PR DESCRIPTION
Not sure if this is necessary for most (and I noticed the v21 plugin has something better), but since I'm constantly outputting different spools for different shots from one file, I tweaked it to add the current date and time to the spool filename to prevent accidentally overwriting the old one, which has happened to me a couple of times so far.

I couldn't think of the best way to structure it, so I just went with the month, day, year, hour, minute, second. It's a lot of digits (13 including underscore) but it tested fine. Not sure if there's any filename length limitations that it might hit on non-windows systems though.