### PR TITLE
Stats.xml changes

### DIFF
--- a/export.py
+++ b/export.py
@@ -2418,7 +2418,7 @@ def export_render_settings(ri, rpass, scene, preview=False):
     ri.Attribute("trace", depths)
     if rm.use_statistics:
         ri.Option("statistics", {'int endofframe': 1,
-                                 'string xmlfilename': 'stats_%d.xml' % scene.frame_current})
+                                 'string xmlfilename': 'stats.%04d.xml' % scene.frame_current})
 
 
 def export_camera_matrix(ri, scene, ob, motion_data=[]):

--- a/export.py
+++ b/export.py
@@ -2418,7 +2418,7 @@ def export_render_settings(ri, rpass, scene, preview=False):
     ri.Attribute("trace", depths)
     if rm.use_statistics:
         ri.Option("statistics", {'int endofframe': 1,
-                                 'string xmlfilename': 'stats.xml'})
+                                 'string xmlfilename': 'stats_%d.xml' % scene.frame_current})
 
 
 def export_camera_matrix(ri, scene, ob, motion_data=[]):

--- a/operators.py
+++ b/operators.py
@@ -76,7 +76,7 @@ class Renderman_open_stats(bpy.types.Operator):
         output_dir = os.path.dirname(
             user_path(rm.path_rib_output, scene=scene))
         bpy.ops.wm.url_open(
-            url="file://" + os.path.join(output_dir, 'stats.xml'))
+            url="file://" + os.path.join(output_dir, 'stats_%d.xml' % scene.frame_current))
         return {'FINISHED'}
 
 

--- a/operators.py
+++ b/operators.py
@@ -67,8 +67,8 @@ from bpy_extras.io_utils import ExportHelper
 
 class Renderman_open_stats(bpy.types.Operator):
     bl_idname = 'rman.open_stats'
-    bl_label = "Open Last Stats"
-    bl_description = "Open Last stats file"
+    bl_label = "Open Frame Stats"
+    bl_description = "Open Current Frame stats file"
 
     def execute(self, context):
         scene = context.scene

--- a/operators.py
+++ b/operators.py
@@ -76,7 +76,7 @@ class Renderman_open_stats(bpy.types.Operator):
         output_dir = os.path.dirname(
             user_path(rm.path_rib_output, scene=scene))
         bpy.ops.wm.url_open(
-            url="file://" + os.path.join(output_dir, 'stats_%d.xml' % scene.frame_current))
+            url="file://" + os.path.join(output_dir, 'stats.%04d.xml' % scene.frame_current))
         return {'FINISHED'}
 
 

--- a/properties.py
+++ b/properties.py
@@ -661,7 +661,7 @@ class RendermanSceneSettings(bpy.types.PropertyGroup):
         min=0.0, max=1024.0, default=10.0)
     use_statistics = BoolProperty(
         name="Statistics",
-        description="Print statistics to /tmp/stats.txt after render",
+        description="Print statistics to stats.xml after render",
         default=False)
     editor_override = StringProperty(
         name="Text Editor",


### PR DESCRIPTION
Makes a stats file per frame when stats are enabled, changes how "Open Last Stats" works to open the stats file for the current frame (if there is one), changes the label from "Open Last Stats" to "Open Frame Stats", and modified the properties text of the enable stats checkbox to better match how the stats are currently output (i.e. .xml, not .txt)


note: I'm not sure how to isolate the changes without the merge from when I updated my fork to be current with master, so sorry about that extra little thing in here.