### PR TITLE
Fix for the RenderMan tool shelf

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -1947,7 +1947,7 @@ class Renderman_UI_Panel(bpy.types.Panel):
                          icon_value=rman_rerender_controls.icon_id)
 
             row.prop(context.scene, "rm_ipr", text="",
-                     icon='DISCLOSURE_TRI_UP' if context.scene.rm_ipr else 'DISCLOSURE_TRI_DOWN')
+                     icon='TRIA_UP' if context.scene.rm_ipr else 'TRIA_DOWN')
 
             if context.scene.rm_ipr:
 
@@ -2033,7 +2033,7 @@ class Renderman_UI_Panel(bpy.types.Panel):
                      text="Add Camera", icon='CAMERA_DATA')
 
         row.prop(context.scene, "prm_cam", text="",
-                 icon='DISCLOSURE_TRI_UP' if context.scene.prm_cam else 'DISCLOSURE_TRI_DOWN')
+                 icon= 'TRIA_UP' if context.scene.prm_cam else 'TRIA_DOWN')
 
         if context.scene.prm_cam:
             ob = bpy.context.object


### PR DESCRIPTION
The latest versions of Blender do not have DISCLOSURE_TRI_UP so changing to TRIA_DOWN seemed like an ok option since it is available in older versions (according to the docs at least.) Let me know if you have any problems with this.