### PR TITLE
Fix Renderman Sampling Integrator Settings assert

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -435,7 +435,7 @@ class RENDER_PT_renderman_sampling(PRManButtonsPanel, Panel):
 
         row = col.row()
         row.prop(rm, "show_integrator_settings", icon=icon, text=text,
-                 icon_only=True, emboss=False)
+                 icon_only=False, emboss=False)
         if rm.show_integrator_settings:
             draw_props(integrator_settings,
                        integrator_settings.prop_names, col)


### PR DESCRIPTION
In debug builds of blender interface_layout.c has an assert that widgets built with icon_only must have an empty description string, otherwise blender will abort.
Release builds ignore the assert and PRMan-for-Blender works properly.

Resolve the issue by setting icon_only to false for the Integrator Settings widget in the Renderman Sampling panel, which allows the text label to be displayed on the widget in both debug and release builds.