### PR TITLE
Only bake bakeable objects

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -769,7 +769,7 @@ class RPass:
         self.ri.Begin(self.paths['rib_output'])
 
         # Check if rendering select objects only.
-        if(self.scene.renderman.render_selected_objects_only):
+        if rm.render_selected_objects_only:
             visible_objects = get_Selected_Objects(self.scene)
         else:
             visible_objects = None

--- a/export.py
+++ b/export.py
@@ -1779,6 +1779,21 @@ def has_emissive_material(db):
     return False
 
 
+def export_for_bake(db):
+    export = True
+    node_names = []
+    for mat in db.material:
+        if mat and mat.node_tree:
+            nt = mat.node_tree
+            for n in nt.nodes:
+                node_names.append(n.name)
+    if node_names:
+        if 'PxrBakeTexture' not in node_names:
+            export = False
+
+    return export
+
+
 # return if a psys should be animated
 # NB:  we ALWAYS need the animating psys if the emitter is transforming,
 # not just if MB is on
@@ -1798,10 +1813,12 @@ def get_instances_and_blocks(obs, rpass):
     scene = rpass.scene
     mb_on = scene.renderman.motion_blur
     mb_segs = scene.renderman.motion_segments
+    bake = rpass.bake
 
     for ob in obs:
         inst = get_instance(ob, rpass.scene, mb_on)
         if inst:
+            do_inst = False
             ob_mb_segs = ob.renderman.motion_segments if ob.renderman.motion_segments_override else mb_segs
 
             # add the instance to the motion segs list if transforming
@@ -1813,6 +1830,7 @@ def get_instances_and_blocks(obs, rpass):
             # now get the data_blocks for the instance
             inst_data_blocks = get_data_blocks_needed(ob, rpass, mb_on)
             for db in inst_data_blocks:
+                do_block = export_for_bake(db)
                 if not db.dupli_data:
                     inst.data_block_names.append(db.name)
 
@@ -1826,9 +1844,12 @@ def get_instances_and_blocks(obs, rpass):
                         motion_segs[ob_mb_segs] = ([], [])
                     motion_segs[ob_mb_segs][1].append(db.name)
 
-                data_blocks[db.name] = db
+                if (bake and do_block) or not bake:
+                    data_blocks[db.name] = db
+                    do_inst = True
 
-            instances[inst.name] = inst
+            if do_inst:
+                instances[inst.name] = inst
 
     return instances, data_blocks, motion_segs
 

--- a/export.py
+++ b/export.py
@@ -1822,7 +1822,7 @@ def get_instances_and_blocks(obs, rpass):
             ob_mb_segs = ob.renderman.motion_segments if ob.renderman.motion_segments_override else mb_segs
 
             # add the instance to the motion segs list if transforming
-            if inst.transforming:
+            if inst.transforming and not bake:
                 if ob_mb_segs not in motion_segs:
                     motion_segs[ob_mb_segs] = ([], [])
                 motion_segs[ob_mb_segs][0].append(inst.name)
@@ -1839,7 +1839,7 @@ def get_instances_and_blocks(obs, rpass):
                     continue
 
                 # add data_block to mb list
-                if db.deforming and mb_on:
+                if db.deforming and mb_on and not bake:
                     if ob_mb_segs not in motion_segs:
                         motion_segs[ob_mb_segs] = ([], [])
                     motion_segs[ob_mb_segs][1].append(db.name)
@@ -3411,7 +3411,8 @@ def write_rib(rpass, scene, ri, visible_objects=None, engine=None, do_objects=Tr
     # export_global_illumination_lights(ri, rpass, scene)
     # export_world_coshaders(ri, rpass, scene) # BBM addition
     export_world(ri, scene.world)
-    export_scene_lights(ri, instances)
+    if not rpass.bake:
+        export_scene_lights(ri, instances)
 
     export_default_bxdf(ri, "default")
     export_materials_archive(ri, rpass, scene)


### PR DESCRIPTION
Doesn't export mesh block or instance for items that do not have a bake node when baking.