### PR TITLE
Userlobe fix

### DIFF
--- a/rman_config/config/rman_dspychan_definitions.json
+++ b/rman_config/config/rman_dspychan_definitions.json
@@ -667,6 +667,11 @@
             "channelSource": "__WNref",
             "group": "Data AOVs"
          },
+         "Albedo":{
+            "channelType": "color",
+            "channelSource": "lpe:nothruput;noinfinitecheck;noclamp;unoccluded;overwrite;CU2L",
+            "group": "User Lobes"
+         },
          "Position":{
             "channelType": "color",
             "channelSource": "lpe:nothruput;noinfinitecheck;noclamp;unoccluded;overwrite;CU3L",
@@ -675,6 +680,11 @@
         "Color":{
             "channelType": "color",
             "channelSource": "lpe:nothruput;noinfinitecheck;noclamp;unoccluded;overwrite;CU4L",
+            "group": "User Lobes"
+        },
+        "Normal":{
+            "channelType": "normal",
+            "channelSource": "lpe:nothruput;noinfinitecheck;noclamp;unoccluded;overwrite;CU6L",
             "group": "User Lobes"
         },
         "NPRshadow": {

--- a/rman_config/config/rman_properties_scene.json
+++ b/rman_config/config/rman_properties_scene.json
@@ -1416,7 +1416,7 @@
             "riopt": "lpe:user3",
             "label": "User 3 Lobe ID",
             "type": "string",
-            "default": "",
+            "default": "Position",
             "always_write": true,
             "help": ""
         },
@@ -1427,7 +1427,7 @@
             "riopt": "lpe:user4",
             "label": "User 4 Lobe ID",
             "type": "string",
-            "default": "",
+            "default": "UserColor",
             "always_write": true,
             "help": ""
         },
@@ -1449,7 +1449,7 @@
             "riopt": "lpe:user6",
             "label": "User 6 Lobe ID",
             "type": "string",
-            "default": "",
+            "default": "Normal,DiffuseNormal,HairTangent,SubsurfaceNormal,SpecularNormal,RoughSpecularNormal,SingleScatterNormal,FuzzNormal,IridescenceNormal,GlassNormal",
             "always_write": true,
             "help": ""
         },


### PR DESCRIPTION
Hello!

Added a couple of missing definitions for LPE User Lobes including U6, which is used to define the normal AOV for the denoiser. Should fix denoised images sometimes being blurrier in Blender.